### PR TITLE
Functional requirements rewrite

### DIFF
--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -52,6 +52,8 @@ Operators
 
 ### Functional Requirements for the Network
 
+Entities able to access the homeserver via the network
+
 1. MUST be able to register a new user
 
 ### Functional Requirements for Users

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -56,7 +56,7 @@ Clients run by federated users. Just like a client, but associated with a federa
 
 The distinction between users their clients is difficult, because the user will perform most of their interactions with the homeserver through the client. Here, we list the operations that, while performed through the client, concern the user as their own entity and might thus also affect all of their clients.
 
-1. MUST be able to manage clients
+1. MUST be able to manage clients (this includes updates to client key material)
 1. SHOULD be able to reset the account if the last client is lost
 1. MUST be able to change their user name
 1. MUST be able to discover other users

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -46,15 +46,15 @@ Federated clients are clients which are run by federated users. They are regular
 
 Operators
 
-1. MUST be able to configure the homeserver and manage its users locally
-1. MUST be able to set the home domain of the homeserver during setup
-1. MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
+1. Homeserver management: MUST be able to configure the homeserver and manage its users locally
+1. Homedomain setup: MUST be able to set the home domain of the homeserver during setup
+1. Federation configuration: MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
 
 ### Functional Requirements for the Network
 
 Entities able to access the homeserver via the network
 
-1. MUST be able to register a new user
+1. User registration: MUST be able to register a new user
 
 ### Functional Requirements for Users
 
@@ -62,13 +62,13 @@ The distinction between users and their clients is difficult because the user wi
 
 Users
 
-1. MUST be able to manage clients (this includes updates to client key material)
-1. SHOULD be able to reset the account if the last client is lost
-1. MUST be able to change their user name
-1. MUST be able to discover other users
-1. MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) of all of the other user's clients)
-1. MUST be able to accept or reject a connection initialized by another (local or federated) user
-1. SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
+1. Client management: MUST be able to manage clients (this includes updates to client key material)
+1. Account reset: SHOULD be able to reset the account if the last client is lost
+1. User name change: MUST be able to change their user name
+1. User discovery: MUST be able to discover other users
+1. Connection establishment: MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) of all of the other user's clients)
+1. Connection rejection: MUST be able to accept or reject a connection initialized by another (local or federated) user
+1. Connection management: SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
 
 ### Functional Requirements for Clients
 
@@ -76,20 +76,20 @@ MLS natively provides a number of group management mechanics such as membership 
 
 Clients
 
-1. MUST be able to initialize an MLS group
-1. MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (this implies the "filtering server" role specified by the ["delivery of messages"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4.3) requirement of the MLS architecture document)
-1. MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement)
-1. MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
-1. MUST be able to fetch their own messages
-1. MUST be able to verify the authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
-1. MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement)
-1. SHOULD be able to configure notification settings of groups of which it is a member
+1. Group creation: MUST be able to initialize an MLS group
+1. Message delivery: MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (this implies the "filtering server" role specified by the ["delivery of messages"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4.3) requirement of the MLS architecture document)
+1. KeyPackage retrieval: MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement)
+1. Welcome message delivery: MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
+1. Message retrieval: MUST be able to fetch their own messages
+1. Client authentication: MUST be able to verify the authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
+1. KeyPackage publishing: jMUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement)
+1. Notification configuration: SHOULD be able to configure notification settings of groups of which it is a member
 
 ### Functional Requirements for Federated Homeservers
 
 Federated homeservers
 
-1. MUST be able to send messages for delivery to one of the homeserver's clients
+1. Federated message delivery: MUST be able to send messages for delivery to one of the homeserver's clients
 
 ### Functional Requirements for Federated Users
 

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -1,22 +1,95 @@
 # Functional Requirements
 
-Before we introduce the architecture and the individual modules, we first define the functional requirements for the homeserver as a whole. We begin with the requirements dictated by the underlying Messaging Layer Security (MLS) protocol. While MLS doesn’t necessarily require a central component like a homeserver, it greatly increases the robustness of the protocol. All references to MLS within this document refer to draft 16 of the MLS specification.
+This section describes the functional requirements of a homeserver. Before we detail the individual requirements, we first introduce the different roles that interact with the system.
 
-- Message distribution: Clients MUST be able to have the homeserver distribute [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to other members of a group.
-- Authentication: Clients MUST be able to authenticate other clients. The homeserver MUST provide the baseline in terms of client authentication by providing a cryptographic link between the user's primary identifier (e.g. a username) of a given user and the key material they use to sign their MLS messages.
-- KeyPackage distribution: Clients MUST be able to upload their own [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) to the homeserver and download those of other clients to facilitate asynchronous group additions.
+Note that while the homeserver should ultimately provide the functionality described, the entity in the given role might have to keep state and perform protocol actions to interact with the homeserver.
 
-Besides these basic functional requirements, a modern messaging infrastructure has to provide a few additional services.
+## Roles
 
-- User and client management: Users MUST be able to register and add or remove clients afterwards, as well as delete their own user account, along with any of their associated data.
-- Queuing: Since message distribution should be possible asynchronously, the homeserver MUST provide a mechanism for messages to be queued until their intended recipient comes online to collect them.
-- Realtime notifications: When a message is queued for a given user, the homeserver MUST try to alert the user in real-time, such that they can retrieve their message. The ability to do so might depend on the user’s client(s).
-- Group management: Message distribution will require that a certain amount of group-specific information is stored on the homeserver. Users MUST be able to manage that information. Ability to manage the group SHOULD be subject to a member’s role in the group (Admin/Member).
-- User discovery: Users MUST be able to find other users by their full, primary identifier and obtain KeyPackages for their client(s).
+A large part of the infrastructure consists of the homeserver, which is operated by the _operator_. The homeserver exposes most of its API endpoints to _clients_ of _users_ that are registered with the homeserver. The remaining endpoints of the homeserver's API are accessible to _the network_, as well as _federated homeservers_. Individuals that are registered with other homeservers are _federated users_ who run _federated clients_.
 
-Finally, homeservers should be able to federate with one-another. The scope of the federation, i.e. with which set of homeserver a given homeserver federates is up to the individual homeserver operators.
+### Operator
 
-- Federated user discovery and KeyPackage distribution: Users on a given homeserver MUST be able to find users on other, federated homeservers and obtain KeyPackages for their client(s).
-- Federated message distribution: Users must be able to send MLS messages to users on a federated homeserver.
+The entity that operates a homeserver. It is assumed to have control over the domain they configure as the homeserver's _home domain_.
 
-Besides these basic example, a modern messenger should enable other sophisticated features such as real time voice and video chat. Since the goal of this project is an initial proof of concept, we omit these for now.
+### The Network
+
+The network includes all entities that have access to the port the homeserver exposes its endpoints on.
+
+### Users
+
+Users are individuals that have registered as users with the homeserver and that are associated with a unique and immutable _user id_ scoped by the homeserver's home domain. Each user also has a unique _user name_. Registered users can have zero or more registered clients.
+
+The user is ultimately the entity that other users authenticate before starting a conversation.
+
+In the context of federation, users of a given homeserver will sometimes be called _local_ users as opposed to _federated_ users.
+
+### Clients
+
+A client is a piece of software associated with and run by a user that. The client holds the key material that authenticate itself (and thus the user) to other clients and their users. Each client is associated with a _client id_ that is scoped by its user's user id.
+
+### Federated Homeservers
+
+Other instances of the homeserver that are reachable via the network, where both the given and the federated homeserver have been configured to allow mutual federation. Each is assumed to be configured with its own home domain.
+
+### Federated Users
+
+Individuals that have registered with a federated homeserver in the same way as users have with the given one.
+
+### Federated Clients
+
+Clients run by federated users. Just like a client, but associated with a federated user instead of a (local) user.
+
+## Functional Requirements for each Role
+
+### Functional Requirements for Homeserver Operators
+
+* MUST be able to configure the homeserver and manage its users locally
+* MUST be able to set the home domain of the homeserver during setup
+* MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
+
+### Functional Requirements for the Network
+
+* MUST be able to register a new user
+
+### Functional Requirements for Users
+
+The distinction between users their clients is difficult, because the user will perform most of their interactions with the homeserver through the client. Here, we list the operations that, while performed through the client, concern the user as their own entity and might thus also affect all of their clients.
+
+* MUST be able to manage clients
+* SHOULD be able to reset the account if the last client is lost
+* MUST be able to change their user name
+* MUST be able to discover other users
+* MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of other user's [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11))
+* MUST be able to accept or reject a connection initialized by another (local or federated) user
+* SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
+
+### Functional Requirements for Clients
+
+MLS natively provides a number of group management mechanics such as membership management. The homeserver's task is thus mostly to deliver individual MLS messages to members of a given group, although the homeserver will likely have to track group membership to fulfill this requirement. Also, it has to provide a number of functionalities, such as the publishing of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) and the delivery of [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to facilitate the group management functionality provided by MLS.
+
+* MUST be able to initialize an MLS group
+* MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of
+* MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection
+* MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
+* MUST be able to fetch own messages
+* MUST be able to verify authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients it shares a group with
+* MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11)
+* SHOULD be able to configure notification settings of groups that it is a member of
+
+### Functional Requirements for Federated Homeservers
+
+* MUST be able to send messages for delivery to one of the homeserver's clients
+
+### Functional Requirements for Federated Users
+
+* MUST be able to discover users of this homeserver
+* MUST be able to initialize a connection with other users of this homeserver (via a two-user MLS group)
+
+### Functional Requirements for Federated Clients
+
+* MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (note that membership management in MLS happens client side, although the homeserver will have to track membership to fulfill this requirement)
+* MUST be able to retrieve KeyPackages for clients of users with a previously established connection
+* MUST be able to send Welcome messages to clients of users with a previously established connection
+* MUST be able to verify authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients
+* SHOULD be able to configure notification settings of groups that it is a member of

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -18,7 +18,7 @@ The network includes all entities that have access to the port the homeserver ex
 
 ### Users
 
-Users are individuals that have registered as users with the homeserver and that are associated with a unique and immutable _user id_ scoped by the homeserver's home domain. Each user also has a unique _user name_. Registered users can have zero or more registered clients.
+Users are individuals that have registered as users with the homeserver and that are associated with a unique and immutable _user id_ scoped by the homeserver's home domain. Each user also has a unique _user name_. Registered users can have one or more registered clients.
 
 The user is ultimately the entity that other users authenticate before starting a conversation.
 
@@ -44,52 +44,48 @@ Clients run by federated users. Just like a client, but associated with a federa
 
 ### Functional Requirements for Homeserver Operators
 
-* MUST be able to configure the homeserver and manage its users locally
-* MUST be able to set the home domain of the homeserver during setup
-* MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
+1. MUST be able to configure the homeserver and manage its users locally
+1. MUST be able to set the home domain of the homeserver during setup
+1. MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
 
 ### Functional Requirements for the Network
 
-* MUST be able to register a new user
+1. MUST be able to register a new user
 
 ### Functional Requirements for Users
 
 The distinction between users their clients is difficult, because the user will perform most of their interactions with the homeserver through the client. Here, we list the operations that, while performed through the client, concern the user as their own entity and might thus also affect all of their clients.
 
-* MUST be able to manage clients
-* SHOULD be able to reset the account if the last client is lost
-* MUST be able to change their user name
-* MUST be able to discover other users
-* MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of other user's [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11))
-* MUST be able to accept or reject a connection initialized by another (local or federated) user
-* SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
+1. MUST be able to manage clients
+1. SHOULD be able to reset the account if the last client is lost
+1. MUST be able to change their user name
+1. MUST be able to discover other users
+1. MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) of all of the other user's clients)
+1. MUST be able to accept or reject a connection initialized by another (local or federated) user
+1. SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
 
 ### Functional Requirements for Clients
 
-MLS natively provides a number of group management mechanics such as membership management. The homeserver's task is thus mostly to deliver individual MLS messages to members of a given group, although the homeserver will likely have to track group membership to fulfill this requirement. Also, it has to provide a number of functionalities, such as the publishing of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) and the delivery of [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to facilitate the group management functionality provided by MLS.
+MLS natively provides a number of group management mechanics such as membership management. The homeserver's task is thus to fulfill the role of an MLS [Delivery Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4).
 
-* MUST be able to initialize an MLS group
-* MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of
-* MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection
-* MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
-* MUST be able to fetch own messages
-* MUST be able to verify authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients it shares a group with
-* MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11)
-* SHOULD be able to configure notification settings of groups that it is a member of
+1. MUST be able to initialize an MLS group
+1. MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (this implies the "filtering server" role specified by the ["delivery of messages"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4.3) requirement of the MLS architecture document)
+1. MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement)
+1. MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
+1. MUST be able to fetch own messages
+1. MUST be able to verify authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients it shares a group with (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
+1. MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement)
+1. SHOULD be able to configure notification settings of groups that it is a member of
 
 ### Functional Requirements for Federated Homeservers
 
-* MUST be able to send messages for delivery to one of the homeserver's clients
+1. MUST be able to send messages for delivery to one of the homeserver's clients
 
 ### Functional Requirements for Federated Users
 
-* MUST be able to discover users of this homeserver
-* MUST be able to initialize a connection with other users of this homeserver (via a two-user MLS group)
+The functional requirements 4. and 5. for local users also apply for federated users.
+
 
 ### Functional Requirements for Federated Clients
 
-* MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (note that membership management in MLS happens client side, although the homeserver will have to track membership to fulfill this requirement)
-* MUST be able to retrieve KeyPackages for clients of users with a previously established connection
-* MUST be able to send Welcome messages to clients of users with a previously established connection
-* MUST be able to verify authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients
-* SHOULD be able to configure notification settings of groups that it is a member of
+The functional requirements 2., 3., 4., 6. and 8. for local clients also apply for federated clients.

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -79,7 +79,7 @@ Clients
 1. MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement)
 1. MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
 1. MUST be able to fetch their own messages
-1. MUST be able to verify the authenticity of an MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
+1. MUST be able to verify the authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
 1. MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement)
 1. SHOULD be able to configure notification settings of groups of which it is a member
 

--- a/src/functional_requirements.md
+++ b/src/functional_requirements.md
@@ -44,58 +44,50 @@ Federated clients are clients which are run by federated users. They are regular
 
 ### Functional Requirements for Homeserver Operators
 
-Operators
-
-1. Homeserver management: MUST be able to configure the homeserver and manage its users locally
-1. Homedomain setup: MUST be able to set the home domain of the homeserver during setup
-1. Federation configuration: MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired
+* Homeserver management: Operators MUST be able to configure the homeserver and manage its users locally.
+* Homedomain setup: Operators MUST be able to set the home domain of the homeserver during setup.
+* Federation configuration: Operators MUST be able to configure federation: Either by allowlisting other homeservers by their home domain, or by allowing open federation except for a blocklist of home domains for homeservers with which federation is not desired.
 
 ### Functional Requirements for the Network
 
-Entities able to access the homeserver via the network
-
-1. User registration: MUST be able to register a new user
+* User registration: Entities in the public network MUST be able to register a new user.
 
 ### Functional Requirements for Users
 
 The distinction between users and their clients is difficult because the user will perform most of their interactions with the homeserver through the client. The following is a list of operations performed through the client, which concern the user as their own entity and might thus also affect all of their clients.
 
-Users
-
-1. Client management: MUST be able to manage clients (this includes updates to client key material)
-1. Account reset: SHOULD be able to reset the account if the last client is lost
-1. User name change: MUST be able to change their user name
-1. User discovery: MUST be able to discover other users
-1. Connection establishment: MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) of all of the other user's clients)
-1. Connection rejection: MUST be able to accept or reject a connection initialized by another (local or federated) user
-1. Connection management: SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore
+* Client management: Users MUST be able to manage clients (this includes updates to client key material).
+* Account reset: Users SHOULD be able to reset the account. Members of groups the user is in MUST be notified by the reset.
+* User name change: Users MUST be able to change their user name. Members of groups the user is in MUST be notified of the new name.
+* User discovery: Users MUST be able to discover other users.
+* Connection establishment: Users MUST be able to initialize a connection with other users (via a two-user MLS group, implies retrieval of [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) of all of the other user's clients)
+* Connection rejection: Users MUST be able to accept or reject a connection initialized by another (local or federated) user. The sender of the connection request SHOULD be notified of the acceptance or rejection of the request.
+* Connection management: Users SHOULD be able to block other (local or federated) users s.t. they don't receive messages from that user anymore. Users SHOULD be able to unblock previously blocked users.
 
 ### Functional Requirements for Clients
 
 MLS natively provides a number of group management mechanics such as membership management. The homeserver's task is thus to fulfill the role of an MLS [Delivery Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4).
 
-Clients
-
-1. Group creation: MUST be able to initialize an MLS group
-1. Message delivery: MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (this implies the "filtering server" role specified by the ["delivery of messages"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4.3) requirement of the MLS architecture document)
-1. KeyPackage retrieval: MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement)
-1. Welcome message delivery: MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection
-1. Message retrieval: MUST be able to fetch their own messages
-1. Client authentication: MUST be able to verify the authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role)
-1. KeyPackage publishing: jMUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement)
-1. Notification configuration: SHOULD be able to configure notification settings of groups of which it is a member
+* Group creation: Clients MUST be able to initialize an MLS group.
+* Message delivery: Clients MUST be able to asynchronously send [MLS messages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-7) to all members of an MLS group that it is a member of (this implies the "filtering server" role specified by the ["delivery of messages"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#section-4.3) requirement of the MLS architecture document). If a given group member has provided the homeserver with a notification for this group, the homeserver MUST attach the notification policy to the message when delivering it. If a group member is a federated client, the homeserver MUST forward the message to the federated homeserver for delivery.
+* Message queuing: The homeserver MUST store messages sent to a client either by itself or forwarded by a federated homeserver while the client is offline.
+* Message notifications: Clients MAY provide the homeserver with a means to notify them when a new message is queued, as well as a default notification policy. If the client has provided the homeserver with such a means and corresponding policy, the homeserver MUST notify the client according to either the policy attached to the message, or, if none was attached, according to the default policy.
+* KeyPackage retrieval: Clients MUST be able to retrieve [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) for clients of users with a previously established connection (this implies the ["key storage"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-storage) requirement). As long as there is more than one KeyPackage, the server MUST delete the KeyPackage after it was provided to a (local or federated) client.
+* Welcome message delivery: Clients MUST be able to send [Welcome](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-13.4.3.1) messages to clients of users with a previously established connection. If the client has provided the homeserver with a means of notification (and default notification policy), the homeserver MUST notify the client according to the default policy.
+* Message retrieval: Clients MUST be able to fetch messages queued by the homeserver.
+* Client authentication: Clients MUST be able to verify the authenticity of MLS leaf [Credentials](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#name-credentials) of clients with which it shares a group (this implies at least partially fulfilling the [Authentication Service](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-authentication-service) role).
+* KeyPackage publishing: Clients MUST be able to publish [KeyPackages](https://www.ietf.org/archive/id/draft-ietf-mls-protocol-16.html#section-11) (this implies the ["key retrieval"](https://www.ietf.org/id/draft-ietf-mls-architecture-08.html#name-key-retrieval) requirement). When a client publishes new KeyPackages, the homeserver MUST delete all remaining previously uploaded KeyPackages of that client.
+* Notification configuration: Clients SHOULD be able to configure notification settings of groups of which it is a member.
 
 ### Functional Requirements for Federated Homeservers
 
-Federated homeservers
-
-1. Federated message delivery: MUST be able to send messages for delivery to one of the homeserver's clients
+* Federated message delivery: Federated homeservers MUST be able to send messages for delivery to one of the homeserver's clients.
 
 ### Functional Requirements for Federated Users
 
-The functional requirements 4. and 5. for local users also apply for federated users.
+The functional requirements _user discovery_ and _connection establishment_ for local users also apply for federated users.
 
 
 ### Functional Requirements for Federated Clients
 
-The functional requirements 2., 3., 4., 6. and 8. for local clients also apply for federated clients.
+The functional requirements _message delivery_, _KeyPackage retrieval_, _welcome message delivery_, _client authentication_ and _notification configuration_ for local clients also apply for federated clients.


### PR DESCRIPTION
TODOs: 
* Add the fact that homeservers need to buffer messages for delivery to federated clients in case that the federated homeserver is offline.
* Add explicit action for group deletion, since the last party can't delete themselves from the group, so it's not covered by membership management.